### PR TITLE
Add page titles, meta tags, and fix theme picker a11y

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -8,7 +8,31 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
     />
-    <script src="https://kit.fontawesome.com/f37ce081d9.js" crossorigin="anonymous"></script>
+    <meta
+      name="description"
+      content="The personal site of Tyler Johnson. Find me on GitHub or drop me an email."
+    />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Tyler Johnson" />
+    <meta property="og:title" content="Tyler Johnson" />
+    <meta
+      property="og:description"
+      content="The personal site of Tyler Johnson. Find me on GitHub or drop me an email."
+    />
+    <meta property="og:url" content="https://tylerjohnson.me/" />
+    <meta property="og:image" content="https://tylerjohnson.me/apple-touch-icon.png" />
+    <meta property="og:image:alt" content="A waving hand" />
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Tyler Johnson" />
+    <meta
+      name="twitter:description"
+      content="The personal site of Tyler Johnson. Find me on GitHub or drop me an email."
+    />
+    <meta name="twitter:image" content="https://tylerjohnson.me/apple-touch-icon.png" />
+
+    <script src="https://kit.fontawesome.com/f37ce081d9.js" crossorigin="anonymous" defer></script>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -25,6 +25,10 @@
   });
 </script>
 
+<svelte:head>
+  <title>404 Not Found · Tyler Johnson</title>
+</svelte:head>
+
 <div class="py-8">
   <div class="container mx-auto flex flex-col gap-2 p-4 font-mono">
     <div class="text-4xl text-base-content/60">This page seems to be</div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -55,15 +55,13 @@
 {@render children?.()}
 
 <div class="dropdown dropdown-top dropdown-end fixed bottom-2 right-2">
-  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-  <!-- svelte-ignore a11y_label_has_associated_control -->
-  <label tabindex="0" class="btn btn-sm btn-primary">
-    Theme <i class="fa-solid fa-caret-up"></i>
-  </label>
+  <!-- A real button is natively focusable, so daisyUI's :focus-within opens the
+       menu without the tabindex/label workaround this used to need. -->
+  <button class="btn btn-sm btn-primary" aria-haspopup="menu">
+    Theme <i class="fa-solid fa-caret-up" aria-hidden="true"></i>
+  </button>
 
-  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <ul
-    tabindex="0"
     class="dropdown-content z-[1] menu flex-nowrap p-2 shadow bg-base-300 rounded-box w-64 mb-2 max-h-[calc(100vh-10rem)] overflow-auto"
   >
     <li>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,3 +1,7 @@
+<svelte:head>
+  <title>Tyler Johnson</title>
+</svelte:head>
+
 <div class="flex items-center justify-center h-full font-mono p-4">
   <div class="flex flex-col gap-8 items-center">
     <div class="flex flex-col items-center gap-2 bg-base-200 rounded-box p-8 text-center">

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -29,8 +29,21 @@ test("theme picker switches the active theme", async ({ page }) => {
   const html = page.locator("html");
   await expect(html).not.toHaveAttribute("data-theme");
 
-  await page.getByText("Theme", { exact: false }).click();
+  await page.getByRole("button", { name: /Theme/ }).click();
   await page.getByRole("button", { name: "Dracula" }).click();
 
   await expect(html).toHaveAttribute("data-theme", "dracula");
+});
+
+test("theme picker is reachable by keyboard", async ({ page }) => {
+  await page.goto("/");
+  const menu = page.locator("ul.dropdown-content");
+  await expect(menu).toBeHidden();
+
+  // The trigger is a real button, so focusing it opens the menu via :focus-within.
+  await page.getByRole("button", { name: /Theme/ }).focus();
+  await expect(menu).toBeVisible();
+
+  await page.keyboard.press("Tab");
+  await expect(page.getByRole("button", { name: "Auto" })).toBeFocused();
 });


### PR DESCRIPTION
Small polish pass on things that were missing rather than broken.

## Titles

The site had no `<title>` anywhere, so tabs and search results fell back to the bare URL. Set per-page via `<svelte:head>` rather than statically in `app.html`, so each page renders exactly one title tag instead of a duplicate:

- index → `Tyler Johnson`
- error → `404 Not Found · Tyler Johnson`

## Meta tags

Added a description plus Open Graph and Twitter card tags. Shared links previously rendered as a bare URL with no title, description, or image.

`og:image` points at the 180×180 `apple-touch-icon.png` with `twitter:card=summary`, which gives a small square preview. A large banner preview would need a dedicated 1200×630 image — not included here.

## Theme picker accessibility

The dropdown trigger was a `<label tabindex="0">` standing in for a button, which required three `svelte-ignore` comments to quiet the warnings. It's now a real `<button aria-haspopup="menu">`, and both `tabindex` hacks are gone.

daisyUI opens the menu off `:focus-within` and a button is natively focusable, so behaviour is unchanged — verified by mouse and keyboard before and after. svelte-check reports 0 warnings with all three suppressions deleted, so these are resolved rather than silenced.

Adds a test covering the keyboard path (focus trigger → menu opens → Tab reaches the first entry) so it can't silently regress.

## Font Awesome

Added `defer` so the third-party kit script stops blocking render.

## Deliberately not changed

Pinch-zoom stays disabled (`maximum-scale=1.0, user-scalable=no`). Flagged as a WCAG 1.4.4 issue; keeping current behaviour by choice.

## Verification

`npm run build`, `npm run check` (0 errors, 0 warnings), `npm run lint`, and `npm test` (8 tests) all pass.